### PR TITLE
Add thumbnail prettification for twitter link

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -24,6 +24,24 @@ Discordrb::LOGGER.mode = :debug
 reserved = %w(등록 삭제 목록 격리 이동)
 
 
+client.message(contains: /\/\/(x|twitter)\.com\//m) do |event|
+    next unless event.server
+    next unless /\/\/(x|twitter)\.com\//m.match(event.message.content)
+
+    event.message.create_reaction("❌")
+
+end
+
+client.reaction_add(emoji: "❌") do |event|
+    next unless event.server
+    next unless event.user == event.message.author
+
+    event.message.delete_all_reactions()
+    modified_content = event.message.content.gsub(/\/\/(x|twitter)\.com\//m, '//vxtwitter.com/')
+
+    event.message.reply!(modified_content, mention_user: true)
+end
+
 client.message(with_text: /\A!(\S+)(.*)/m) do |event|
     next unless event.server
     next unless /\A!(\S+)(.*)/m.match(event.message.content)


### PR DESCRIPTION
## 발단
디코에 x.com 이나 twitter.com 링크로 글을 올리면 썸네일이 안이쁘게 나오거나 아예 안나옵니다.
fxtwitter나 vxtwitter로 링크를 치환하면 썸네일이 이쁘게 나옵니다.
근데 이걸 일일이 고치고있기가 힘듦니다.

## 구현 내용
![Honeycam 2023-08-16 02-12-31](https://github.com/synthdnb/discord-bot/assets/1228030/b01cf910-73f0-4e0f-8698-65e4e6d1f15d)
x.com이나 twitter.com이 담긴 링크가 올라오면 ❌ 리액션을 달아줍니다.
그 후 "원 글을 쓴 사람이" ❌ 리액션을 누르면 기존 리액션을 삭제하고 fx/vxtwitter 링크를 담아 멘션을 씁니다.

## Comment
- [Discord API에 다른 사람의 메시지를 수정하는 기능이 막혀있어서](https://discord.com/developers/docs/resources/channel#edit-message) 우회적으로 위처럼 구현했습니다.
- fxtwitter나 vxtwitter를 쓰면 되는데 경험상 vxtwitter가 더 안정적으로 나오는 것 같아서 이쪽으로 결정했습니다.

## 테스트 항목
- x.com이나 twitter.com 이외의 URL에 대해 오동작하지 않는 것을 확인했습니다.